### PR TITLE
refactor: add CI/CD coverage pipeline and docker/structure cleanup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,53 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "feature/**"
+
+jobs:
+  test-and-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests with coverage gate
+        env:
+          COVERAGE_THRESHOLD: "55"
+        run: make test-cover-enforce
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile
+          path: coverage.out

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ ui/static/images/*.jpg
 ui/static/images/*.gif
 tls/*.pem
 .env
+coverage.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,27 @@
-# Use a specific version of the Golang base image for building
-FROM golang:1.20-alpine AS build
+FROM golang:1.26-alpine AS build
 
-# Set metadata
-LABEL version="1.0" maintainer="asharip <aspandyart@gmail.com>"
+WORKDIR /src
 
-ENV GO111MODULE=on
+RUN apk add --no-cache build-base
 
-# Set the working directory
-WORKDIR /app
-
-# Copy Go module files for dependency management
 COPY go.mod go.sum ./
-
-COPY /ui/. /app/ui
-
-# Download dependencies
 RUN go mod download
 
-# Copy the application source code
 COPY . .
+RUN CGO_ENABLED=1 GOOS=linux go build -o /bin/forum ./cmd/web
 
-# Build the application
-RUN apk add --no-cache build-base  \
-&& go build -o main ./cmd/web/*
+FROM alpine:3.22
 
-# Create a minimal runtime image
-FROM alpine:latest
-
-# Set the working directory
 WORKDIR /app
 
-# Copy the ts.db file and the database initialization script
-COPY st.db init-up.sql ./
+RUN apk add --no-cache ca-certificates && adduser -D -u 10001 forum
 
-# Copy the built binary from the build stage
-COPY --from=build /app .
+COPY --from=build /bin/forum /app/forum
+COPY init-up.sql /app/init-up.sql
+COPY ui /app/ui
 
-# Expose the port the application listens on
+USER forum
+
 EXPOSE 4000
 
-# Define the command to run the application
-CMD ["./main"]
+CMD ["./forum"]

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ start:
 	(cd $(TLS_DIR) && go run $(GO_ENV_GOROOT)/src/crypto/tls/generate_cert.go --rsa-bits=2048 --host=localhost)
 
 build:
-	docker build --tag ${APPLICATION_NAME} .
+	docker compose build
 
 run:
-	docker run -d -p 4000:4000 --rm --name ${DOCKER_USERNAME} ${APPLICATION_NAME}
+	docker compose up -d
 
 stop:
-	docker stop ${DOCKER_USERNAME}
+	docker compose down
 
 
 test-cover:

--- a/README.md
+++ b/README.md
@@ -55,9 +55,15 @@ make run
 make stop
 ```
 
-`make run` maps `4000:4000`, so the app remains available at:
+`make run` maps `4001:4000`, so the app remains available at:
 
-`[https://localhost:4000](https://localhost:4000)`
+`[https://localhost:4001](https://localhost:4001)`
+
+The Docker workflow now uses `docker-compose.yml`, mounting:
+
+- `.env` into container runtime environment
+- `st.db` at `/app/st.db`
+- `tls/` at `/app/tls` (read-only)
 
 ## Testing and Coverage
 
@@ -85,6 +91,11 @@ Override threshold when needed:
 make test-cover-enforce COVERAGE_THRESHOLD=80
 ```
 
+## CI/CD
+
+- `CI` workflow runs on pull requests and pushes to `main`/`feature/*`, executes `make test-cover-enforce`, and uploads `coverage.out`.
+- `CD` workflow runs on pushes to `main` and `v*` tags, then builds and pushes the Docker image to `ghcr.io/<owner>/<repo>`.
+
 ## Documentation
 
 - Development setup, env vars, TLS details, troubleshooting: `[docs/development.md](docs/development.md)`
@@ -95,6 +106,3 @@ make test-cover-enforce COVERAGE_THRESHOLD=80
 ## Authors
 
 - `@aspandyar`
-
-
-

--- a/cmd/web/auth_handlers.go
+++ b/cmd/web/auth_handlers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aspandyar/forum/internal/models"
+	sessioncookie "github.com/aspandyar/forum/internal/transport/http/sessioncookie"
 	"github.com/aspandyar/forum/internal/validator"
 )
 
@@ -131,7 +132,7 @@ func (app *application) userLoginPost(w http.ResponseWriter, r *http.Request) {
 		app.serverError(w, err)
 		return
 	}
-	models.SetSessionCookie(w, session.Token, session.Expiry)
+	sessioncookie.SetSessionCookie(w, session.Token, session.Expiry)
 
 	http.Redirect(w, r, "/forum/create", http.StatusSeeOther)
 }
@@ -149,6 +150,6 @@ func (app *application) userLogoutPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	models.ClearSessionCookie(w)
+	sessioncookie.ClearSessionCookie(w)
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/cmd/web/envfile_compat.go
+++ b/cmd/web/envfile_compat.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/aspandyar/forum/internal/config/envfile"
+
+func LoadEnvFromFile(filename string) error {
+	return envfile.Load(filename)
+}

--- a/cmd/web/helpers.go
+++ b/cmd/web/helpers.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"net/http"
-	"os"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -67,38 +65,4 @@ func (app *application) processTags(selectedTags []string, customTagsStr string)
 	}
 
 	return tags
-}
-
-func LoadEnvFromFile(filename string) error {
-	file, err := os.Open(filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	// Create a map to store key-value pairs
-	envVars := make(map[string]string)
-
-	// Read and parse the file line by line
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) == 2 {
-			key := strings.TrimSpace(parts[0])
-			value := strings.TrimSpace(parts[1])
-			envVars[key] = value
-		}
-	}
-
-	// Set the environment variables
-	for key, value := range envVars {
-		os.Setenv(key, value)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"flag"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -12,7 +11,9 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/aspandyar/forum/internal/config/envfile"
 	"github.com/aspandyar/forum/internal/models"
+	"github.com/aspandyar/forum/internal/security/tlsconfig"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -39,7 +40,7 @@ func main() {
 	infoLog := log.New(os.Stdout, "INFO\t", log.Ldate|log.Ltime)
 	errorLog := log.New(os.Stderr, "ERROR\t", log.Ldate|log.Ltime|log.Lshortfile)
 
-	err := LoadEnvFromFile(".env")
+	err := envfile.Load(".env")
 	if err != nil {
 		log.Fatal("Error loading .env file:", err)
 	}
@@ -121,7 +122,7 @@ func openDB(path string) (*sql.DB, error) {
 }
 
 func readDB(path string, db *sql.DB) {
-	sqlScript, err := ioutil.ReadFile(path)
+	sqlScript, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -137,4 +138,16 @@ func readDB(path string, db *sql.DB) {
 			}
 		}
 	}
+}
+
+func ConfigureCipherSuites(config *tls.Config, cipherSuites []uint16) {
+	tlsconfig.ConfigureCipherSuites(config, cipherSuites)
+}
+
+func SetMinTLSVersion(config *tls.Config, version uint16) {
+	tlsconfig.SetMinTLSVersion(config, version)
+}
+
+func SetMaxTLSVersion(config *tls.Config, version uint16) {
+	tlsconfig.SetMaxTLSVersion(config, version)
 }

--- a/cmd/web/oauth_handlers.go
+++ b/cmd/web/oauth_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aspandyar/forum/internal/models"
 	githuboauth "github.com/aspandyar/forum/internal/oauth/github"
 	googleoauth "github.com/aspandyar/forum/internal/oauth/google"
+	sessioncookie "github.com/aspandyar/forum/internal/transport/http/sessioncookie"
 	"github.com/aspandyar/forum/internal/validator"
 )
 
@@ -51,7 +52,7 @@ func (app *application) handleGoogleCallback(w http.ResponseWriter, r *http.Requ
 				app.serverError(w, err)
 				return
 			}
-			models.SetSessionCookie(w, session.Token, session.Expiry)
+			sessioncookie.SetSessionCookie(w, session.Token, session.Expiry)
 			http.Redirect(w, r, "/forum/create", http.StatusSeeOther)
 		} else {
 			app.serverError(w, err)
@@ -74,7 +75,7 @@ func (app *application) handleGoogleCallback(w http.ResponseWriter, r *http.Requ
 		app.serverError(w, err)
 		return
 	}
-	models.SetSessionCookie(w, session.Token, session.Expiry)
+	sessioncookie.SetSessionCookie(w, session.Token, session.Expiry)
 	http.Redirect(w, r, "/forum/create", http.StatusSeeOther)
 }
 
@@ -129,7 +130,7 @@ func (app *application) loggedinHandler(w http.ResponseWriter, r *http.Request, 
 				return
 			}
 
-			models.SetSessionCookie(w, session.Token, session.Expiry)
+			sessioncookie.SetSessionCookie(w, session.Token, session.Expiry)
 			http.Redirect(w, r, "/forum/create", http.StatusSeeOther)
 			return
 		}
@@ -153,7 +154,7 @@ func (app *application) loggedinHandler(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	models.SetSessionCookie(w, session.Token, session.Expiry)
+	sessioncookie.SetSessionCookie(w, session.Token, session.Expiry)
 	http.Redirect(w, r, "/forum/create", http.StatusSeeOther)
 }
 

--- a/cmd/web/request_helpers.go
+++ b/cmd/web/request_helpers.go
@@ -2,16 +2,16 @@ package main
 
 import (
 	"net/http"
-	"strconv"
-	"strings"
+
+	requestpkg "github.com/aspandyar/forum/internal/transport/http/request"
 )
 
 func pathParts(r *http.Request) []string {
-	return strings.Split(r.URL.Path, "/")
+	return requestpkg.PathParts(r)
 }
 
 func pathInt(parts []string, idx int) (int, error) {
-	return strconv.Atoi(parts[idx])
+	return requestpkg.PathInt(parts, idx)
 }
 
 func (app *application) sessionUserID(r *http.Request) (int, error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  forum:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: forum:local
+    container_name: forumContainer
+    ports:
+      - "4001:4000"
+    env_file:
+      - .env
+    volumes:
+      - ./st.db:/app/st.db
+      - ./.env:/app/.env:ro
+      - ./tls:/app/tls:ro
+    restart: unless-stopped

--- a/internal/config/envfile/load.go
+++ b/internal/config/envfile/load.go
@@ -1,0 +1,38 @@
+package envfile
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+func Load(filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	envVars := make(map[string]string)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			envVars[key] = value
+		}
+	}
+
+	for key, value := range envVars {
+		os.Setenv(key, value)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/models/session_cookie_compat.go
+++ b/internal/models/session_cookie_compat.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"net/http"
+	"time"
+
+	sessioncookie "github.com/aspandyar/forum/internal/transport/http/sessioncookie"
+)
+
+func SetSessionCookie(w http.ResponseWriter, token string, expiration time.Time) {
+	sessioncookie.SetSessionCookie(w, token, expiration)
+}
+
+func ClearSessionCookie(w http.ResponseWriter) {
+	sessioncookie.ClearSessionCookie(w)
+}

--- a/internal/models/sessions.go
+++ b/internal/models/sessions.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"database/sql"
-	"net/http"
 	"time"
 
 	"github.com/google/uuid"
@@ -77,29 +76,6 @@ func (m *SessionModel) GetSession(token string) (int, time.Time, error) {
 	}
 	parsedTime, _ := time.Parse("2006-01-02 15:04:05.999999999-07:00", expiry)
 	return userID, parsedTime, nil
-}
-
-func SetSessionCookie(w http.ResponseWriter, token string, expiration time.Time) {
-	sessionCookie := &http.Cookie{
-		Name:     "session",
-		Value:    token,
-		Expires:  expiration,
-		Path:     "/",
-		Secure:   true,                    // Set the Secure attribute to true
-		HttpOnly: true,                    // Recommended to set HttpOnly to prevent JavaScript access
-		SameSite: http.SameSiteStrictMode, // Recommended for security
-	}
-	http.SetCookie(w, sessionCookie)
-}
-
-func ClearSessionCookie(w http.ResponseWriter) {
-	expiredCookie := &http.Cookie{
-		Name:    "session",
-		Value:   "",
-		Expires: time.Now().Add(-1 * time.Hour),
-		Path:    "/",
-	}
-	http.SetCookie(w, expiredCookie)
 }
 
 func (m *SessionModel) InvalidateSession(token string) error {

--- a/internal/security/tlsconfig/tlsconfig.go
+++ b/internal/security/tlsconfig/tlsconfig.go
@@ -1,4 +1,4 @@
-package main
+package tlsconfig
 
 import "crypto/tls"
 

--- a/internal/transport/http/request/path.go
+++ b/internal/transport/http/request/path.go
@@ -1,0 +1,15 @@
+package request
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func PathParts(r *http.Request) []string {
+	return strings.Split(r.URL.Path, "/")
+}
+
+func PathInt(parts []string, idx int) (int, error) {
+	return strconv.Atoi(parts[idx])
+}

--- a/internal/transport/http/sessioncookie/cookie.go
+++ b/internal/transport/http/sessioncookie/cookie.go
@@ -1,0 +1,29 @@
+package sessioncookie
+
+import (
+	"net/http"
+	"time"
+)
+
+func SetSessionCookie(w http.ResponseWriter, token string, expiration time.Time) {
+	sessionCookie := &http.Cookie{
+		Name:     "session",
+		Value:    token,
+		Expires:  expiration,
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	}
+	http.SetCookie(w, sessionCookie)
+}
+
+func ClearSessionCookie(w http.ResponseWriter) {
+	expiredCookie := &http.Cookie{
+		Name:    "session",
+		Value:   "",
+		Expires: time.Now().Add(-1 * time.Hour),
+		Path:    "/",
+	}
+	http.SetCookie(w, expiredCookie)
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow to run coverage enforcement and publish `coverage.out` artifact, plus CD workflow to build/push image to GHCR on `main` and tags
- fix container workflow by modernizing `Dockerfile`, adding `docker-compose.yml`, switching Make targets to Compose, and documenting runtime port `4001`
- reduce file crowding by extracting web/model utilities into focused packages (`internal/config/envfile`, `internal/security/tlsconfig`, `internal/transport/http/request`, `internal/transport/http/sessioncookie`) while keeping compatibility wrappers and behavior intact

## Test plan
- [x] `go test ./...`
- [x] `COVERAGE_THRESHOLD=55 make test-cover-enforce`
- [x] `docker compose config`
- [x] `docker build -t forum:test .`
- [x] `docker compose up -d` and `docker compose ps`
- [ ] Manual browser sanity at `https://localhost:4001`

## Notes
- CI threshold is set to `55` for now to match the repository's current baseline and prevent false failures.

Made with [Cursor](https://cursor.com)